### PR TITLE
Drop footer on first page to reduce whitespace in single page letters

### DIFF
--- a/letter-template.tex
+++ b/letter-template.tex
@@ -13,7 +13,9 @@
     fromemail,           % show email
     $endif$
     fromlogo,            % show logo in letter head
-    version=last         % latest version of KOMA letter
+    version=last,        % latest version of KOMA letter
+    firstfoot=false,     % no footer on first page
+    enlargefirstpage
 ]{scrlttr2}
 
 \usepackage[ngerman]{babel}


### PR DESCRIPTION
This allows one to fit more text on single-page letters.